### PR TITLE
Fix "sign in" translation

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = {
         auth: {
             username: 'Usuario',
             password: 'Contraseña',
-            sign_in: 'Registrarse',
+            sign_in: 'Acceder',
             sign_in_error: 'La autenticación falló, por favor, vuelva a intentarlo',
             logout: 'Cerrar Sesión',
         },


### PR DESCRIPTION
Hi,

ra.auth.sign_in "Registrarse" current translation is incorrect as it means "Sign up". Previous translation "Acceder" was better IMHO.

Changed it it my fork. Maybe you want to merge it.