### PR TITLE
Missing colon

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = {
             page_out_of_boundaries: 'Número de página %{page} fuera de los límites',
             page_out_from_end: 'No puede ir después de la última página',
             page_out_from_begin: 'No puede ir antes de la página 1',
-            page_rows_per_page: 'Filas por página',
+            page_rows_per_page: 'Filas por página:',
             page_range_info: '%{offsetBegin}-%{offsetEnd} de %{total}',
             next: 'Siguiente',
             prev: 'Anterior',


### PR DESCRIPTION
My company QA noticed that a colon is missing, IMO that should've been added separately but react-admin does it that way, so I'm adding that, sorry for not noticing before. 